### PR TITLE
Add Dockerfile for Scala 2.11

### DIFF
--- a/2.11/Dockerfile
+++ b/2.11/Dockerfile
@@ -1,0 +1,11 @@
+FROM codingame/sbt:0.13.13
+
+ENV SCALA_VERSION 2.11.8
+ENV SCALA_ARCHIVE http://www.scala-lang.org/files/archive/scala-${SCALA_VERSION}.tgz
+ENV SCALA_HOME    /usr/local/share/scala
+ENV PATH          ${PATH}:${SCALA_HOME}/bin
+
+# Install Scala
+RUN mkdir -p "$SCALA_HOME" \
+	&& curl -sSL "$SCALA_ARCHIVE" \
+	| tar -xzC "$SCALA_HOME" --strip-components=1


### PR DESCRIPTION
Combine Scala and sbt into a single image.

This will be useful for runners that have an `onbuild` script.